### PR TITLE
feat: support bin command for bun

### DIFF
--- a/postinstall-debug-package/postinstall.js
+++ b/postinstall-debug-package/postinstall.js
@@ -275,6 +275,9 @@ async function getEnvAddedByPackageManager(
     ? ['pnpm', 'bin'].concat(isGlobalMode ? '--global' : [])
     : packageManager?.name === 'npm'
     ? ['npm', 'bin'].concat(isGlobalMode ? '--global' : [])
+    : packageManager?.name === 'bun'
+    ? // see https://bun.sh/docs/install/utilities
+      ['bun', 'pm', 'bin'].concat(isGlobalMode ? '--global' : [])
     : null;
   const binCommandResult =
     binCommandArgs &&


### PR DESCRIPTION
npm has the `npm bin --global` command, yarn has the `yarn global bin` command, and pnpm has the `pnpm bin --global` command.
For bun, there is [a `bun pm bin --global` command](https://bun.sh/docs/install/utilities).