### PR TITLE
feat: remove postinstall results from the console

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "fmt": "prettier --write '**/*'"
   },
   "dependencies": {
+    "ansi-colors": "4.1.3",
     "used-pm": "1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ patchedDependencies:
     path: patches/used-pm@1.0.0.patch
 
 dependencies:
+  ansi-colors:
+    specifier: 4.1.3
+    version: 4.1.3
   used-pm:
     specifier: 1.0.0
     version: 1.0.0(patch_hash=vagrn54hxsys32i3eqkpm4xpyq)
@@ -450,6 +453,11 @@ packages:
       uri-js: 4.4.1
     dev: true
     optional: true
+
+  /ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+    dev: false
 
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}

--- a/postinstall-debug-package/postinstall.js
+++ b/postinstall-debug-package/postinstall.js
@@ -3,6 +3,7 @@ const { appendFile, readdir, readFile, writeFile } = require('fs/promises');
 const path = require('path');
 const { inspect, promisify } = require('util');
 
+const ansiColors = require('ansi-colors');
 const usedPM = require('used-pm');
 
 const execAsync = promisify(exec);
@@ -261,8 +262,11 @@ async function getEnvAddedByPackageManager(
 }
 
 (async () => {
+  ansiColors.enabled = true;
   console.log(
-    `Start postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+    ansiColors.green(
+      `Start postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+    ),
   );
 
   const cwd = process.cwd();
@@ -371,7 +375,9 @@ async function getEnvAddedByPackageManager(
   }
 
   console.log(
-    `Finish postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+    ansiColors.green(
+      `Finish postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+    ),
   );
 })().catch((error) => {
   if (!process.exitCode) process.exitCode = 1;

--- a/postinstall-debug-package/postinstall.js
+++ b/postinstall-debug-package/postinstall.js
@@ -261,6 +261,10 @@ async function getEnvAddedByPackageManager(
 }
 
 (async () => {
+  console.log(
+    `Start postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+  );
+
   const cwd = process.cwd();
   const pkg = await readFile(path.resolve(__dirname, 'package.json'), 'utf8')
     .then((v) => JSON.parse(v))
@@ -324,8 +328,6 @@ async function getEnvAddedByPackageManager(
       prefixesToCompareRecord: expectedValues,
     }),
   };
-  if (postinstallType) console.log(postinstallType);
-  console.log(debugData);
 
   const {
     GITHUB_STEP_SUMMARY,
@@ -367,6 +369,10 @@ async function getEnvAddedByPackageManager(
        */
       await appendFile(DEBUG_DATA_JSON_LINES_PATH, `\n${jsonStr}\n`);
   }
+
+  console.log(
+    `Finish postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+  );
 })().catch((error) => {
   if (!process.exitCode) process.exitCode = 1;
   console.error(error);

--- a/postinstall-debug-package/postinstall.js
+++ b/postinstall-debug-package/postinstall.js
@@ -265,7 +265,7 @@ async function getEnvAddedByPackageManager(
   ansiColors.enabled = true;
   console.log(
     ansiColors.green(
-      `Start postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+      `Start postinstall${postinstallType ? ` / ${postinstallType}` : ''}`,
     ),
   );
 
@@ -376,7 +376,7 @@ async function getEnvAddedByPackageManager(
 
   console.log(
     ansiColors.green(
-      `Finish postinstall${postinstallType ? ` (${postinstallType})` : ''}`,
+      `Finish postinstall${postinstallType ? ` / ${postinstallType}` : ''}`,
     ),
   );
 })().catch((error) => {


### PR DESCRIPTION
I now check postinstall results with the job summary. I do not use the console.
And if I show long results in the console, it will be difficult to see the results for each package manager.