### PR TITLE
perf(./postinstall-debug-package/postinstall.ts): avoid generating formatted output

### DIFF
--- a/.github/workflows/run-install.cts
+++ b/.github/workflows/run-install.cts
@@ -11,7 +11,7 @@ import type * as ActionsIo from '@actions/io';
 import type * as ActionsExec from '@actions/exec';
 
 import { envDiff } from './utils/env-diff';
-import type { OutputData as OutputDataFromPostinstall } from '../../postinstall-debug-package/postinstall';
+import type { OutputData as OutputDataFromPostinstall } from '../../postinstall-debug-package/types';
 
 const BIN_NAME = 'bar';
 

--- a/.github/workflows/run-install.cts
+++ b/.github/workflows/run-install.cts
@@ -10,6 +10,9 @@ import type * as ActionsCore from '@actions/core';
 import type * as ActionsIo from '@actions/io';
 import type * as ActionsExec from '@actions/exec';
 
+import { envDiff } from './utils/env-diff';
+import type { OutputData as OutputDataFromPostinstall } from '../../postinstall-debug-package/postinstall';
+
 const BIN_NAME = 'bar';
 
 function defaultItemIfEmptyArray<T extends readonly unknown[], U>(
@@ -67,16 +70,53 @@ function updatePathEnv<T extends string | undefined>(
   return updatedEnv;
 }
 
-interface DebugDataFromPostinstall {
-  readonly postinstallType: string | null;
-  readonly cwd: string;
-  readonly binCommand: {
-    readonly args: readonly string[];
-    readonly result: string | null;
-  } | null;
-  readonly isGlobalMode: boolean;
-  readonly binName: string | null;
-  readonly env: Readonly<Record<string, string | null>>;
+function genJobSummaryLines(args: {
+  debugDataList: readonly OutputDataFromPostinstall[];
+  expectedValues: Readonly<Record<string, unknown>>;
+  originalEnv: Readonly<NodeJS.ProcessEnv>;
+}): string[] {
+  return args.debugDataList.flatMap(
+    ({
+      postinstallType,
+      actual: { env: postinstallEnv, binCommandResult, ...debugData },
+    }) => {
+      const binCommand = binCommandResult
+        ? {
+            args: [
+              binCommandResult.readableCommand.command,
+              ...binCommandResult.readableCommand.args,
+            ],
+            result: binCommandResult,
+          }
+        : null;
+      return [
+        `<details>`,
+        ...(postinstallType ? [`<summary>${postinstallType}</summary>`] : []),
+        '',
+        '```js',
+        inspect(
+          {
+            ...args.expectedValues,
+            ...debugData,
+            ...(binCommand
+              ? {
+                  [binCommand.args.join(' ')]: binCommand.result,
+                }
+              : {}),
+            env: envDiff(args.originalEnv, postinstallEnv, {
+              cwd: debugData.cwd,
+              prefixesToCompareRecord: args.expectedValues,
+            }),
+          },
+          { depth: Infinity },
+        ),
+        '```',
+        '',
+        '</details>',
+        '',
+      ];
+    },
+  );
 }
 
 interface MainArgs {
@@ -369,7 +409,6 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
   const tmpDirpath = await fs.mkdtemp(os.tmpdir() + path.sep);
   const installEnv = Object.assign({}, defaultEnv, {
     DEBUG_DATA_JSON_LINES_PATH: path.join(tmpDirpath, 'debug-data.jsonl'),
-    DEBUG_ORIGINAL_ENV_JSON_PATH: path.join(tmpDirpath, 'orig-env.json'),
   });
   if (pnp) {
     // see https://github.com/pnpm/pnpm/blob/v5.9.0/packages/pnpm/CHANGELOG.md#590
@@ -587,30 +626,26 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
       const setupResult = await setup({ pkgJson });
       if (!setupResult) return null;
       const { expectedLocalPrefix } = setupResult;
+      const expectedValues = {
+        expectedPnPEnabled: pnp,
+        expectedLocalPrefix,
+      };
+
       await fs.writeFile(pkgJsonPath, JSON.stringify(pkgJson));
 
       const localInstallEnv = Object.assign({}, installEnv, {
         POSTINSTALL_TYPE: `Local Dependencies (${caseName})`,
-        DEBUG_EXPECTED_VARS_JSON: JSON.stringify({
-          expectedPnPEnabled: pnp,
-          expectedLocalPrefix,
-        }),
+        DEBUG_EXPECTED_VARS_JSON: JSON.stringify(expectedValues),
       });
-      await fs.writeFile(
-        localInstallEnv.DEBUG_ORIGINAL_ENV_JSON_PATH,
-        JSON.stringify(localInstallEnv, (_, value) =>
-          value === undefined ? null : value,
-        ),
-      );
       await fs.writeFile(
         localInstallEnv.DEBUG_DATA_JSON_LINES_PATH,
         new Uint8Array(0),
       );
 
-      return { projectRootPath, localInstallEnv };
+      return { projectRootPath, expectedValues, localInstallEnv };
     });
     if (!setupResult) continue;
-    const { projectRootPath, localInstallEnv } = setupResult;
+    const { projectRootPath, expectedValues, localInstallEnv } = setupResult;
 
     const { executablesFilepathList: installedExecutables } =
       await findInstalledNpmExecutables(
@@ -661,10 +696,25 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
           localInstallEnv,
         });
 
+        const debugDataList = await fs
+          .readFile(localInstallEnv.DEBUG_DATA_JSON_LINES_PATH, 'utf8')
+          .then(
+            parseJsonLines as (
+              jsonLinesText: string,
+            ) => OutputDataFromPostinstall[],
+          )
+          .catch(() => []);
+        const jobSummaryLines = genJobSummaryLines({
+          debugDataList,
+          expectedValues,
+          originalEnv: localInstallEnv,
+        });
+
         if (installedExecutables.length < 1) {
           await fs.appendFile(
             GITHUB_STEP_SUMMARY,
             [
+              ...jobSummaryLines,
               '*No executables created in `node_modules/.bin` directory.*',
               '',
               '',
@@ -676,31 +726,24 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
         const binDirSet = new Set(
           installedExecutables.map((filepath) => path.dirname(filepath)),
         );
-        const debugData = await fs
-          .readFile(localInstallEnv.DEBUG_DATA_JSON_LINES_PATH, 'utf8')
-          .then(parseJsonLines)
-          .then(
-            (
-              debugDataList,
-            ): DebugDataFromPostinstall | Partial<DebugDataFromPostinstall> =>
-              (debugDataList as unknown as DebugDataFromPostinstall[]).find(
-                ({ postinstallType }) =>
-                  postinstallType === localInstallEnv.POSTINSTALL_TYPE,
-              ) ??
-              // Bun does not execute the "postinstall" script of installed dependencies.
-              // Instead, it uses the debug data from the project's "postinstall" script.
-              (debugDataList as unknown as DebugDataFromPostinstall[]).find(
-                ({ postinstallType }) =>
-                  pmType === 'bun' &&
-                  postinstallType &&
-                  /^(?:Project|Package)\b/i.test(postinstallType),
-              ) ??
-              {},
-          )
-          .catch(() => ({} as Partial<DebugDataFromPostinstall>));
+        const debugData =
+          debugDataList.find(
+            ({ postinstallType }) =>
+              postinstallType === localInstallEnv.POSTINSTALL_TYPE,
+          ) ??
+          // Bun does not execute the "postinstall" script of installed dependencies.
+          // Instead, it uses the debug data from the project's "postinstall" script.
+          debugDataList.find(
+            ({ postinstallType }) =>
+              pmType === 'bun' &&
+              postinstallType &&
+              /^(?:Project|Package)\b/i.test(postinstallType),
+          ) ??
+          null;
         await fs.appendFile(
           GITHUB_STEP_SUMMARY,
           [
+            ...jobSummaryLines,
             '```js',
             await Promise.all(
               [...binDirSet].map(async (binDir) => [
@@ -709,7 +752,7 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
                   '// This path can also be got using environment variables:',
                   filepathUsingEnvNameList(
                     binDir,
-                    debugData.env,
+                    debugData?.actual.env,
                     localInstallEnv,
                   ).map(({ path }) => path),
                   '//     ',
@@ -891,6 +934,10 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
     null,
   )) {
     const labelSuffix = caseItem ? ` (${caseItem[0]})` : '';
+    const expectedValues = {
+      expectedPnPEnabled: pnp,
+    };
+
     const { globalInstallEnv } = await core.group(
       `Setup${labelSuffix}`,
       async () => {
@@ -900,20 +947,12 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
 
         Object.assign(globalInstallEnv, {
           POSTINSTALL_TYPE: `Global Dependencies${labelSuffix}`,
-          DEBUG_EXPECTED_VARS_JSON: JSON.stringify({
-            expectedPnPEnabled: pnp,
-          }),
+          DEBUG_EXPECTED_VARS_JSON: JSON.stringify(expectedValues),
         });
         if (pmType === 'yarn' && !isYarnBerry && pnp) {
           // see https://github.com/yarnpkg/yarn/pull/6382
           globalInstallEnv['YARN_PLUGNPLAY_OVERRIDE'] = '1';
         }
-        await fs.writeFile(
-          getRequiredEnv('DEBUG_ORIGINAL_ENV_JSON_PATH', { globalInstallEnv }),
-          JSON.stringify(globalInstallEnv, (_, value) =>
-            value === undefined ? null : value,
-          ),
-        );
         await fs.writeFile(
           getRequiredEnv('DEBUG_DATA_JSON_LINES_PATH', { globalInstallEnv }),
           new Uint8Array(0),
@@ -985,13 +1024,12 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
           .catch((error) => {
             if (error.code === 'ENOENT') return [];
             throw error;
-          })) as DebugDataFromPostinstall[];
-        const { binCommand, ...debugData } =
-          debugDataList.find(
-            ({ postinstallType }) =>
-              postinstallType ===
-              getRequiredEnv('POSTINSTALL_TYPE', { globalInstallEnv }),
-          ) ?? ({} as Partial<DebugDataFromPostinstall>);
+          })) as OutputDataFromPostinstall[];
+        const debugData = debugDataList.find(
+          ({ postinstallType }) =>
+            postinstallType ===
+            getRequiredEnv('POSTINSTALL_TYPE', { globalInstallEnv }),
+        );
         async function inspectInstalledBin(
           bindirPath: string,
         ): Promise<string> {
@@ -1014,6 +1052,18 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
             .catch((error) => inspect(error));
         }
 
+        const binCommand = debugData?.actual.binCommandResult
+          ? ({
+              args: [
+                debugData.actual.binCommandResult.readableCommand.command,
+                ...debugData.actual.binCommandResult.readableCommand.args,
+              ],
+              result: debugData.actual.binCommandResult.error
+                ? null
+                : debugData.actual.binCommandResult.stdout,
+            } as const)
+          : null;
+
         const binCommandMap = new Map<string, string>();
         if (binCommand?.result) {
           binCommandMap.set(binCommand.args.join(' '), binCommand.result);
@@ -1031,8 +1081,8 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
 
         if (binDirSet.size < 1) {
           const prefixEnvName = 'npm_config_prefix';
-          if (debugData.env?.[prefixEnvName]) {
-            const prefix = debugData.env[prefixEnvName];
+          if (debugData?.actual.env[prefixEnvName]) {
+            const prefix = debugData.actual.env[prefixEnvName];
             // see https://docs.npmjs.com/cli/v9/configuring-npm/folders#executables
             const binDir =
               process.platform === 'win32' ? prefix : path.join(prefix, 'bin');
@@ -1046,6 +1096,11 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
         await fs.appendFile(
           GITHUB_STEP_SUMMARY,
           [
+            ...genJobSummaryLines({
+              debugDataList,
+              expectedValues,
+              originalEnv: globalInstallEnv,
+            }),
             '```js',
             await Promise.all(
               [...binDirSet].map(async (binDir) => [
@@ -1054,7 +1109,7 @@ module.exports = async ({ core, io, exec, packageManager, pnp }: MainArgs) => {
                   '// This path can also be got using environment variables:',
                   filepathUsingEnvNameList(
                     binDir,
-                    debugData.env,
+                    debugData?.actual.env,
                     globalInstallEnv,
                   ).map(({ path }) => path),
                   '//     ',

--- a/.github/workflows/utils/env-diff.ts
+++ b/.github/workflows/utils/env-diff.ts
@@ -1,0 +1,122 @@
+import * as path from 'node:path';
+import { inspect } from 'node:util';
+import type { InspectOptions } from 'node:util';
+
+/**
+ * @see https://nodejs.org/api/util.html#custom-inspection-functions-on-objects
+ */
+type CustomInspectFunction<TThis = unknown> = (
+  this: TThis,
+  depth: number,
+  options: Readonly<InspectOptions>,
+  _inspect: typeof inspect,
+) => string;
+
+type PrefixRecord = Record<string, unknown>;
+
+function genValueInspectFn(
+  args: Readonly<{
+    prefixRecord: Readonly<PrefixRecord>;
+    key: string;
+    value: Readonly<NodeJS.ProcessEnv[string]>;
+    origValue: Readonly<NodeJS.ProcessEnv[string]>;
+  }>,
+): CustomInspectFunction {
+  let commentList: string[] = [];
+  const overwriteOptions: InspectOptions = {};
+
+  if (/^PATH$/i.test(args.key) && typeof args.value === 'string') {
+    const pathList = args.value
+      .split(path.delimiter)
+      .map((path) => `- ${path}`);
+    if (
+      typeof args.origValue === 'string' &&
+      args.origValue.length < args.value.length &&
+      args.value.endsWith(args.origValue)
+    ) {
+      // Omit duplicate $PATH values
+      overwriteOptions.maxStringLength =
+        args.value.length - args.origValue.length;
+      const origPathLength = args.origValue.split(path.delimiter).length;
+      pathList.splice(
+        -origPathLength,
+        origPathLength,
+        `... ${origPathLength} more paths`,
+      );
+    }
+    commentList = ['PATH List:', ...pathList];
+  } else if (typeof args.value === 'string') {
+    const value = args.value;
+    const compareList = Object.entries(args.prefixRecord).flatMap(
+      ([name, prefix]) => {
+        if (typeof prefix === 'string' && value.startsWith(prefix))
+          return `  ${name}${
+            value !== prefix
+              ? ` + ${inspect(value.substring(prefix.length))}`
+              : ''
+          }`;
+        return [];
+      },
+    );
+    if (0 < compareList.length) {
+      commentList = ['Equal to this:', ...compareList];
+    }
+  }
+
+  return 0 < commentList.length
+    ? (_depth, options, inspect) =>
+        `(\n${(
+          inspect(args.value, { ...options, ...overwriteOptions }) +
+          commentList.map((comment) => `\n// ${comment}`).join('')
+        ).replace(/^(?!$)/gm, '  ')}\n)`
+    : (_depth, options, inspect) =>
+        inspect(args.value, { ...options, ...overwriteOptions });
+}
+
+export function envDiff(
+  env1: Readonly<NodeJS.ProcessEnv>,
+  env2: Readonly<Record<string, NodeJS.ProcessEnv[string] | null>>,
+  {
+    cwd,
+    prefixesToCompareRecord,
+  }: {
+    cwd?: string;
+    prefixesToCompareRecord?: Readonly<PrefixRecord>;
+  } = {},
+): NodeJS.ProcessEnv & {
+  readonly [inspect.custom]: CustomInspectFunction<NodeJS.ProcessEnv>;
+} {
+  const prefixRecord: PrefixRecord = Object.assign(
+    cwd ? { 'process.cwd()': cwd } : {},
+    prefixesToCompareRecord,
+  );
+
+  const customInspect: CustomInspectFunction<NodeJS.ProcessEnv> = function (
+    _depth,
+    options,
+    inspect,
+  ) {
+    const entries = Object.entries(this).map(([key, value]) => [
+      key,
+      {
+        [inspect.custom]: genValueInspectFn({
+          prefixRecord,
+          key,
+          value,
+          origValue: env1[key],
+        }),
+      },
+    ]);
+    return inspect(Object.fromEntries(entries), options);
+  };
+
+  const envEntries = Object.entries(env2).map(
+    ([key, value]) => [key, value ?? undefined] as const,
+  );
+  return Object.assign(
+    Object.fromEntries(
+      envEntries.filter(([key, value]) => env1[key] !== value),
+    ),
+    { [inspect.custom]: customInspect },
+  );
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prettier": "2.8.7",
     "prettier-package-json": "2.8.0",
     "sort-package-json": "2.4.1",
+    "type-fest": "3.11.0",
     "typescript": "5.0.4"
   },
   "packageManager": "pnpm@8.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ devDependencies:
   sort-package-json:
     specifier: 2.4.1
     version: 2.4.1
+  type-fest:
+    specifier: 3.11.0
+    version: 3.11.0
   typescript:
     specifier: 5.0.4
     version: 5.0.4
@@ -1660,6 +1663,11 @@ packages:
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@3.11.0:
+    resolution: {integrity: sha512-JaPw5U9ixP0XcpUbQoVSbxSDcK/K4nww20C3kjm9yE6cDRRhptU28AH60VWf9ltXmCrIfIbtt9J+2OUk2Uqiaw==}
+    engines: {node: '>=14.16'}
     dev: true
 
   /typescript@5.0.4:

--- a/postinstall-debug-package/postinstall.ts
+++ b/postinstall-debug-package/postinstall.ts
@@ -3,39 +3,12 @@ import * as path from 'path';
 import { inspect } from 'util';
 
 import ansiColors from 'ansi-colors';
-import type { JsonObject } from 'type-fest';
 
 import { isGlobalMode } from './utils/is-global-mode';
 import { isPnPEnabled } from './utils/is-pnp-enabled';
 import { execBinCmd } from './utils/exec-bin-cmd';
 import { findInstalledExecutables } from './utils/find-installed-executables';
-
-export interface OutputData extends JsonObject {
-  readonly postinstallType: string | null;
-  readonly binName: string | null;
-  readonly actual: {
-    readonly cwd: string;
-    readonly env: Readonly<Record<string, string | null>>;
-    readonly pnpVersion: string | null;
-    readonly isGlobalMode: boolean;
-    readonly binCommandResult:
-      | ({
-          readonly stdout: string;
-          readonly stderr: string;
-          readonly error: string | null;
-        } & Readonly<
-          Record<
-            `${'readable' | 'executed'}Command`,
-            {
-              readonly command: string;
-              readonly args: readonly string[];
-            }
-          >
-        >)
-      | null;
-    readonly foundBinFiles: readonly string[] | null;
-  };
-}
+import type { OutputData } from './types';
 
 const postinstallType =
   process.argv

--- a/postinstall-debug-package/types.ts
+++ b/postinstall-debug-package/types.ts
@@ -1,0 +1,28 @@
+import type { JsonObject } from 'type-fest';
+
+export interface OutputData extends JsonObject {
+  readonly postinstallType: string | null;
+  readonly binName: string | null;
+  readonly actual: {
+    readonly cwd: string;
+    readonly env: Readonly<Record<string, string | null>>;
+    readonly pnpVersion: string | null;
+    readonly isGlobalMode: boolean;
+    readonly binCommandResult:
+      | ({
+          readonly stdout: string;
+          readonly stderr: string;
+          readonly error: string | null;
+        } & Readonly<
+          Record<
+            `${'readable' | 'executed'}Command`,
+            {
+              readonly command: string;
+              readonly args: readonly string[];
+            }
+          >
+        >)
+      | null;
+    readonly foundBinFiles: readonly string[] | null;
+  };
+}


### PR DESCRIPTION
The `postinstall.js` file should be simple.
Output to be written to the job summary can also be generated in `.github/workflows/run-install.cjs`.